### PR TITLE
Fix RPC over HTTP2

### DIFF
--- a/Infra/envoy/envoy.yaml
+++ b/Infra/envoy/envoy.yaml
@@ -18,8 +18,6 @@ static_resources:
                 stat_prefix: ingress_http
                 http2_protocol_options: {}
                 stream_idle_timeout: 300s
-                http_protocol_options:
-                  accept_http_10: true
                 access_log:
                   - name: envoy.access_loggers.stdout
                     typed_config:
@@ -34,8 +32,8 @@ static_resources:
                           - prefix: "https://"
                           - prefix: "http://"
                         allow_methods: "GET, PUT, DELETE, POST, OPTIONS"
-                        allow_headers: "authorization,content-type,x-amz-date,x-amz-content-sha256,x-amz-security-token,x-forwarded-proto,x-forwarded-host,connect-protocol-version"
-                        expose_headers: "etag,connect-protocol-version"
+                        allow_headers: "authorization,content-type,x-amz-date,x-amz-content-sha256,x-amz-security-token,connect-protocol-version,connect-timeout-ms,x-requested-with,x-user-agent,x-grpc-web,grpc-status,grpc-message,grpc-accept-encoding,grpc-timeout,grpc-status-details-bin,origin,access-control-request-method,access-control-request-headers"
+                        expose_headers: "connect-protocol-version,connect-timeout-ms,grpc-status,grpc-message,grpc-accept-encoding,grpc-timeout,grpc-status-details-bin,access-control-allow-origin,access-control-allow-credentials"
                         max_age: "86400"
                       routes:
                         # Connect API endpoint
@@ -44,38 +42,22 @@ static_resources:
                           route:
                             cluster: api_service
                             timeout: 30s
-                            retry_policy:
-                              retry_on: "connect-failure,refused-stream,unavailable,cancelled,resource-exhausted,deadline-exceeded"
-                              num_retries: 3
-                              per_try_timeout: 15s
                         # Health check endpoint
                         - match:
                             prefix: "/health"
                           route:
                             cluster: api_service
                             timeout: 5s
-                        # Next.js webpack HMR
-                        - match:
-                            prefix: "/_next/webpack-hmr"
-                          route:
-                            cluster: frontend_service
-                            timeout: 0s
-                            upgrade_configs:
-                              - upgrade_type: "websocket"
                         # Default route to frontend
                         - match:
                             prefix: "/"
                           route:
                             cluster: frontend_service
                             timeout: 30s
-                            retry_policy:
-                              retry_on: "connect-failure,refused-stream,503,reset,5xx"
-                              num_retries: 3
-                              per_try_timeout: 5s
-                              retry_back_off:
-                                base_interval: 0.1s
-                                max_interval: 1s
                 http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
                   - name: envoy.filters.http.cors
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
@@ -129,7 +111,14 @@ static_resources:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
           explicit_http_config:
-            http2_protocol_options: {} # Enable HTTP/2 for Connect-RPC
+            http2_protocol_options: {} # Use HTTP/2 to talk to the API server
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: thread-art-generator-api-1
+          common_tls_context:
+            alpn_protocols: ["h2"]
       load_assignment:
         cluster_name: api_service
         endpoints:
@@ -141,27 +130,10 @@ static_resources:
                       port_value: 9090
       connect_timeout: 30s
       dns_lookup_family: V4_ONLY
-      health_checks:
-        - timeout: 1s
-          interval: 10s
-          unhealthy_threshold: 3
-          healthy_threshold: 1
-          http_health_check:
-            path: "/health"
-            expected_statuses:
-              start: 200
-              end: 299
 
     - name: frontend_service
       type: STRICT_DNS
       lb_policy: ROUND_ROBIN
-      typed_extension_protocol_options:
-        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-          common_http_protocol_options:
-            idle_timeout: 3600s
-          explicit_http_config:
-            http_protocol_options: {}
       load_assignment:
         cluster_name: frontend_service
         endpoints:
@@ -172,13 +144,3 @@ static_resources:
                       address: thread-art-generator-frontend-1
                       port_value: 3000
       connect_timeout: 5s
-      health_checks:
-        - timeout: 2s
-          interval: 5s
-          unhealthy_threshold: 2
-          healthy_threshold: 1
-          http_health_check:
-            path: "/"
-            expected_statuses:
-              start: 200
-              end: 399

--- a/core/util/config.go
+++ b/core/util/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	GCSBucketName       string        `mapstructure:"GCS_BUCKET_NAME"`
 	SendInBlueAPIKey    string        `mapstructure:"SENDINBLUE_API_KEY"`
 	FrontendUrl         string        `mapstructure:"FRONTEND_URL"`
+	TLSCertFile         string        `mapstructure:"TLS_CERT_FILE"`
+	TLSKeyFile          string        `mapstructure:"TLS_KEY_FILE"`
 	Auth0               Auth0Config   `mapstructure:",squash"`
 	Storage             StorageConfig `mapstructure:",squash"`
 	Queue               QueueConfig   `mapstructure:",squash"`
@@ -81,6 +83,8 @@ func LoadConfig() (config Config, err error) {
 	viper.BindEnv("GCS_BUCKET_NAME")
 	viper.BindEnv("SENDINBLUE_API_KEY")
 	viper.BindEnv("FRONTEND_URL")
+	viper.BindEnv("TLS_CERT_FILE")
+	viper.BindEnv("TLS_KEY_FILE")
 	viper.BindEnv("AUTH0_DOMAIN")
 	viper.BindEnv("AUTH0_AUDIENCE")
 	viper.BindEnv("AUTH0_CLIENT_ID")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
       AUTH0_MANAGEMENT_API_CLIENT_ID: ${AUTH0_MANAGEMENT_API_CLIENT_ID}
       AUTH0_MANAGEMENT_API_CLIENT_SECRET: ${AUTH0_MANAGEMENT_API_CLIENT_SECRET}
+      TLS_CERT_FILE: ${TLS_CERT_FILE:-/certs/tag.local.crt}
+      TLS_KEY_FILE: ${TLS_KEY_FILE:-/certs/tag.local.key}
       # Storage configuration
       STORAGE_PROVIDER: ${STORAGE_PROVIDER}
       STORAGE_BUCKET: ${STORAGE_BUCKET}
@@ -41,6 +43,8 @@ services:
       # Queue configuration
       RABBITMQ_URL: ${RABBITMQ_URL}
       QUEUE_COMPOSITION_PROCESSING: ${QUEUE_COMPOSITION_PROCESSING}
+    volumes:
+      - ./certs:/certs
     depends_on:
       - db
       - migrations

--- a/threadGenerator/thread_generator.go
+++ b/threadGenerator/thread_generator.go
@@ -120,20 +120,6 @@ func (tg *ThreadGenerator) SetImage(imagePath string) {
 	tg.imageName = imagePath
 }
 
-func (tg *ThreadGenerator) getDefaults() {
-	tg.nailsQuantity = 300
-	tg.imgSize = 800
-	tg.maxPaths = 10000
-	tg.startingNail = 0
-	tg.minimumDifference = 10
-	tg.brightnessFactor = 50
-	tg.imageContrast = 40
-	tg.physicalRadius = 609.6 // 24 inches
-	tg.rotationAxis = "A"
-	tg.needleAxis = "X"
-	tg.spindleAxis = "Y"
-}
-
 func (tg *ThreadGenerator) mergeArgs(args Args) error {
 	// Don't reset to defaults here - only apply values from args if provided
 


### PR DESCRIPTION
This pull request introduces significant updates to the Envoy proxy configuration, enhances HTTP/2 support with TLS, and improves logging and error handling in the gRPC client. It also includes cleanup of unused defaults in the thread generator and updates to the Docker Compose setup for TLS support.

### Envoy Proxy Configuration Updates:
* Removed `http_protocol_options` and added the `grpc_web` HTTP filter to support gRPC-Web. Simplified retry policies and removed health checks for specific routes. [[1]](diffhunk://#diff-5a3cd0510d659436c320d6cabda0f02f105edb856038303d9abf55864fdcd454L21-L22) [[2]](diffhunk://#diff-5a3cd0510d659436c320d6cabda0f02f105edb856038303d9abf55864fdcd454L47-R60) [[3]](diffhunk://#diff-5a3cd0510d659436c320d6cabda0f02f105edb856038303d9abf55864fdcd454L144-L164) [[4]](diffhunk://#diff-5a3cd0510d659436c320d6cabda0f02f105edb856038303d9abf55864fdcd454L175-L184)
* Expanded CORS headers to include additional gRPC-specific headers for better compatibility with gRPC-Web clients.
* Added upstream TLS configuration with SNI and ALPN protocols to enable secure communication with the API server over HTTP/2.

### HTTP/2 with TLS Support:
* Updated `runConnectServer` in `cmd/api/main.go` to configure HTTP/2 with TLS, falling back to HTTP/1.1 if TLS certificates are not provided.
* Added `TLSCertFile` and `TLSKeyFile` fields to the configuration struct and bound them to environment variables. [[1]](diffhunk://#diff-6012188d202546b7e98df0a01fad422f786bb40f3edbf318c325a87f04249aa6R60-R61) [[2]](diffhunk://#diff-6012188d202546b7e98df0a01fad422f786bb40f3edbf318c325a87f04249aa6R86-R87)
* Updated `docker-compose.yml` to include TLS certificate volumes and environment variables for local development. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R31-R32) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R46-R47)

### gRPC Client Improvements:
* Enhanced logging in `grpc-client.ts` to include debug information for token fetching, service calls, and error processing. [[1]](diffhunk://#diff-1c4f6b5b1c69ba56b0e8b36b174c895b2116d229b2a861f7be8243bf65f93335R43) [[2]](diffhunk://#diff-1c4f6b5b1c69ba56b0e8b36b174c895b2116d229b2a861f7be8243bf65f93335R54) [[3]](diffhunk://#diff-1c4f6b5b1c69ba56b0e8b36b174c895b2116d229b2a861f7be8243bf65f93335R88-R102) [[4]](diffhunk://#diff-1c4f6b5b1c69ba56b0e8b36b174c895b2116d229b2a861f7be8243bf65f93335R112)
* Updated transport setup to explicitly document communication through the Envoy proxy.

### Code Cleanup:
* Removed the unused `getDefaults` method from the `ThreadGenerator` class to simplify the codebase.